### PR TITLE
Optional use of cookie consent.

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -43,6 +43,13 @@ paginate = 5
   # verification string for Yandex Webmaster Tools
   #yandex_verify_meta = "66b077430f35f04a"
 
+  # Cookie consent (my be required for your site in the European Union)
+  # Set the "more info" URL in this parameter. You have to
+  # provide a document page for this URL - see the example website
+  # To avoid a menu entry for this information page add it to
+  # conten/info instead of content/page or content.
+  # cookie_consent_info_url = "/cookie-information/"
+
   [params.sidebar]
     # Optional about block for sidebar (can be Markdown)
     about = "A simple Hugo theme based on the [Bootstrap v4 blog example](http://v4-alpha.getbootstrap.com/examples/blog/)."

--- a/exampleSite/content/info/cookieinformation.md
+++ b/exampleSite/content/info/cookieinformation.md
@@ -1,0 +1,22 @@
++++
+date = "2014-11-20T13:49:43+01:00"
+title = "Cookie information"
+draft = false
+description = "Information about use of cookies on this site."
+url = "/cookie-information/"
+
++++
+
+This site uses cookies - small text files that are placed on your machine.
+
+To be able to optimize the site and to measure it's success
+the site uses third party cookies by Google Analytics.
+
+You may prefer to disable cookies on this site and on others.
+The most effective way to do this is to disable cookies in your browser.  
+I suggest consulting the Help section of your browser or taking a
+look at <a href="http://www.aboutcookies.org" target="_blank">the About Cookies website</a>
+which offers guidance for all modern browsers.
+
+<a href="https://tools.google.com/dlpage/gaoptout?hl=en" target="_blank">Google also provides a browser plugin</a> which disables tracking through
+Google Analytics.

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,7 +16,11 @@
     <link href="{{ .Site.RSSLink }}" type="application/rss+xml" rel="alternate">
 
     {{ template "_internal/google_analytics_async.html" . }}
-  </head>
+
+    {{ if .Site.Params.cookie_consent_info_url }}
+      {{ partial "cookie_consent.html" . }}
+    {{ end }}
+</head>
 
 <body>
 
@@ -24,7 +28,7 @@
     <div class="container">
       <nav class="nav blog-nav">
         <a class="nav-link {{ if .IsHome }}active{{ end }}" href="{{ .Site.BaseURL | absLangURL }}">{{ i18n "home" }}</a>
-        {{ range where .Site.Pages "Type" "!=" "post" }}
+        {{ range where .Site.Pages "Type" "==" "page" }}
         <a class="nav-link" href="{{ .Permalink }}">{{ .Title }}</a>
         {{ end }}
       </nav>


### PR DESCRIPTION
Hi Alan,

I included cookie consent into my blog. Now I changed it that it's configurable.
Setting the url in the configuration enables cookie consent.
The url points to an explanation page which is called by pressing "more info" in the cookie consent bar.

The European Union requires now that web pages include a means by which the user is at least informed about the use of cookies and has to accept it by taking some action.

I also changed the base template to ONLY include nodes of type "page" in the main menu.
This way you can move the cookie information to a different archetype and don't have it
displayed in the main menu.

I hope you like the change.

Regards,
Frank Tegtmeyer