### PR TITLE
Add custom navbar support

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,5 +1,5 @@
 # Hugo variables
-# 
+#
 baseurl = "https://example.org/"
 languageCode = "en-us"
 title = "Hugo Bootstrap v4 Blog"
@@ -22,6 +22,14 @@ paginate = 5
 [[menu.sidebar]]
   name = "Link 2"
   url = "https://example.org"
+
+# custom navbar menu entry.   See the custom_navbar parameter below for
+# details.
+
+#[[menu.navbar]]
+#  name = "Link 1"
+#  url = "https://example.org"
+
 
 # Theme variables
 #
@@ -50,6 +58,15 @@ paginate = 5
   # site or externally, for example:
   #cookie_consent_info_url = "/cookie-information/"
   #cookie_consent_info_url = "http://cookiesandyou.com"
+
+  # customise the contents of the navbar at the top of the page.  The default
+  # behaviour is to list all static pages not in the posts directory. When the
+  # parameter below is set to true you will have to manually add entries to the
+  # navbar, either by adding the following menu variable to the front matter of
+  # the relevant pages
+  #   menu = "navbar"
+  # or by specifying menu entries in a similar way to the sidebar menu above.
+  #custom_navbar = true
 
   [params.sidebar]
     # Optional about block for sidebar (can be Markdown)

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -31,8 +31,14 @@
     <div class="container">
       <nav class="nav blog-nav">
         <a class="nav-link {{ if .IsHome }}active{{ end }}" href="{{ .Site.BaseURL | absLangURL }}">{{ i18n "home" }}</a>
-        {{ range where .Site.Pages "Type" "!=" "post" }}
-        <a class="nav-link" href="{{ .Permalink }}">{{ .Title }}</a>
+        {{ if .Site.Params.custom_navbar }}
+          {{ range .Site.Menus.navbar }}
+          <a class="nav-link" href="{{.URL | absURL }}">{{ .Name }}</a>
+          {{ end }}
+        {{ else }}
+          {{ range where .Site.Pages "Type" "!=" "post" }}
+          <a class="nav-link" href="{{ .Permalink }}">{{ .Title }}</a>
+          {{ end }}
         {{ end }}
       </nav>
     </div>


### PR DESCRIPTION
- default behaviour is backward compatible: all non-post pages
- optionally enable custom navbar using hugo menu functionality

See also #13