### PR TITLE
Add ability to insert custom code into the global <head>.

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -23,6 +23,8 @@
     {{ if .Site.Params.cookie_consent_info_url }}
     {{ partial "cookie-consent.html" . }}
     {{ end }}
+
+		{{ partial "head-custom.html" . }}
   </head>
 
 <body>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -24,7 +24,7 @@
     {{ partial "cookie-consent.html" . }}
     {{ end }}
 
-		{{ partial "head-custom.html" . }}
+    {{ partial "head-custom.html" . }}
   </head>
 
 <body>

--- a/layouts/partials/head-custom.html
+++ b/layouts/partials/head-custom.html
@@ -1,0 +1,1 @@
+<!-- Create <project-root>/layouts/partials/head-custom.html to overwrite this empty template and put custom code into the <head> section. -->


### PR DESCRIPTION
The change is pretty simple. I wanted to put some custom JavaScript in the &lt;head&gt; of a site I'm building, but I didn't want to have to edit the theme or make a copy of `layouts/_default/baseof.html`, since later changes to the theme may break it. This change allows code to be insterted into &lt;head&gt; by creating a `layouts/partial/head-custom.html`.