### PR TITLE
Add caching of last N posts in sidebar to improve performance

### DIFF
--- a/layouts/partials/recent.html
+++ b/layouts/partials/recent.html
@@ -1,0 +1,9 @@
+  <section class="sidebar-module">
+    <h4>{{ i18n "recentPosts" }}</h4>
+    <ol class="list-unstyled">
+{{ $num_recent_posts := (index .Site.Params.sidebar "num_recent_posts" | default 5) }}
+{{ range first $num_recent_posts (where .Site.RegularPages "Type" "post") }}
+<li><a href="{{.RelPermalink}}">{{.Title | markdownify }}</a></li>
+{{ end }}
+    </ol>
+  </section>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -7,17 +7,7 @@
   {{ end }}
 
   {{ if .Site.Params.sidebar }}
-  {{ $num_recent_posts := (index .Site.Params.sidebar "num_recent_posts" | default 5) }}
-
-  <section class="sidebar-module">
-    <h4>{{ i18n "recentPosts" }}</h4>
-    <ol class="list-unstyled">
-      {{ range first $num_recent_posts (where .Site.RegularPages "Type" "post") }}
-      <li><a href="{{.RelPermalink}}">{{.Title | markdownify }}</a></li>
-      {{ end }}
-    </ol>
-  </section>
-
+      {{ partialCached "recent.html" .}}
   {{ end }}
 
   {{ with .Site.Menus.sidebar }}


### PR DESCRIPTION
While [debugging some performance issues](https://discuss.gohugo.io/t/debugging-performance-problems-with-a-theme/5768/4) I followed the suggestion of @bep and moved the recent posts calculation out into a cached partial. This took my site generation time down from >2m to 18 seconds.