### PR TITLE
Option to display full post content in list template

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ See [picturingjordan.com](https://picturingjordan.com) for an example of this th
 - Supports Disqus comments, see [Hugo docs](https://gohugo.io/extras/comments/)
 - Can show a message about cookie usage to the user, see [`exampleSite/config.toml`](https://github.com/alanorth/hugo-theme-bootstrap4-blog/blob/master/exampleSite/config.toml)
 - Allow addition of custom `<head>` code in site's `layouts/partial/head-custom.html` (see [#17](https://github.com/alanorth/hugo-theme-bootstrap4-blog/pull/17))
+- Configurable display of summaries of content in list templates.
 
 ## Usage
 Clone the repository to your site's `themes` directory. Refer to [`exampleSite/config.toml`](https://github.com/alanorth/hugo-theme-bootstrap4-blog/blob/master/exampleSite/config.toml) for recommended configuration values.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -71,6 +71,9 @@ paginate = 5
   # show sharing icons on pages/posts (default: true)
   #sharingicons = true
 
+  # Display post summaries instead of content in list templates (default: true)
+  # truncate = true
+
   [params.sidebar]
     # Optional about block for sidebar (can be Markdown)
     about = "A simple Hugo theme based on the [Bootstrap v4 blog example](http://v4-alpha.getbootstrap.com/examples/blog/)."

--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -1,0 +1,11 @@
+{{ $dateFormat := default "Mon Jan 2, 2006" (index .Site.Params "date_format") }}
+
+<article class="blog-post">
+  <header>
+    <h2 class="blog-post-title"><a href="{{ .Permalink }}">{{ .Title | markdownify }}</a></h2>
+    <p class="blog-post-meta"><time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format $dateFormat }}</time> by {{ .Params.author | default .Site.Params.author }}{{ if or (.Params.categories) (.Params.tags) }} in {{ partial "meta-terms.html" . }}{{ end }}</p>
+  </header>
+  {{ .Content }}
+</article> <!-- /.blog-post -->
+
+{{- /* vim: set ts=2 sw=2 et: */}}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,4 +1,5 @@
 {{ define "schema-dot-org" }}
+
 <script type="application/ld+json">
 {
   "@context": "http://schema.org",
@@ -29,9 +30,14 @@
 
 {{ define "main" }}
 
+{{ $truncate := default true .Site.Params.truncate }}
 {{ $paginator := .Paginate (where .Data.Pages "Type" "post") }}
 {{ range $paginator.Pages }}
+{{ if $truncate }}
 {{ .Render "summary" }}
+{{ else }}
+{{ .Render "content" }}
+{{ end }}
 {{ end }}
 
 {{ if or (.Paginator.HasPrev) (.Paginator.HasNext) }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,5 +1,4 @@
 {{ define "schema-dot-org" }}
-
 <script type="application/ld+json">
 {
   "@context": "http://schema.org",


### PR DESCRIPTION
It's nice to have the option to let visitors read content right from the homepage without having to click through a summary. This PR introduces the optional "truncate" site parameter.

* If the truncate parameter is not present or is set to true, posts in the list template are rendered as they have always been, with the "summary" content view.
* If the truncate paramter is explicitly set to false, posts in the list template are rendered via a newly introduced "content" content view that displays the full post .Content and does not append a "read more" link.
