### PR TITLE
add a little padding around a code block

### DIFF
--- a/source/scss/main.scss
+++ b/source/scss/main.scss
@@ -179,6 +179,11 @@ article blockquote {
   border-left: $blockquote-border-width solid $blockquote-border-color;
 }
 
+// ensure that code text doesn't butt up against the background change
+article div.highlight {
+  padding: 5px 5px 0px 5px;
+}
+
 /*
  * Footer
  */


### PR DESCRIPTION
if you have formatted code in a post it's a little ugly because it goes from a white background to a  grey with no space around the characters so they're right at the edge, this fixes that.

if you want to play with it in a browser, this post of mine has lots of code https://xenoterracide.com/post/single-repository-one-aggregate/