### PR TITLE
Simplify site-specific css tweaks.

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -68,6 +68,12 @@ paginate = 5
   # or by specifying menu entries in a similar way to the sidebar menu above.
   #custom_navbar = true
 
+  # The css stylesheet included with the theme is minified, which makes it
+  # difficult to tweak just one or two styles. Optionally create
+  # static/css/site-style.css and uncomment the line below, or add as many
+  # files to the array as you wish with paths relative to your site root.
+  #custom_css = ["css/site-style.css"]
+
   # show sharing icons on pages/posts (default: true)
   #sharingicons = true
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -14,6 +14,9 @@
 
     {{ "<!-- combined, minified CSS -->" | safeHTML }}
     <link href="{{ .Site.BaseURL }}css/style.css" rel="stylesheet" integrity="{{ .Site.Data.sri.style}}" crossorigin="anonymous">
+    {{ range .Site.Params.custom_css }}
+    <link rel="stylesheet" href="{{ $.Site.BaseURL }}{{ . }}">
+    {{ end }}
 
     {{ if .RSSLink }}
     {{ "<!-- RSS 2.0 feed -->" | safeHTML }}


### PR DESCRIPTION
This hugo forum post (about a different theme) pretty well sums up the issue: https://discuss.gohugo.io/t/how-to-override-css-classes-with-hugo/3033

It's currently a pain to make small site-specific customizations to the stylesheet because Hugo only allows overrides at the file-level. This PR adds a custom_css array to site parameters, and if set appends the sheets to baseof.html so they take precedence over the default style.

Manually tested with and without custom_css set, confirmed that the style links appear and disappear as expected, and that the styles take take effect when present.