### PR TITLE
Better text for navigation (German)

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -17,7 +17,7 @@
   translation: "Teilen"
 
 - id: paginatorPrevious
-  translation: "Vorige Seite"
+  translation: "Voherige Seite"
 
 - id: paginatorNext
   translation: "Nächste Seite"


### PR DESCRIPTION
Hi Alan,

I was convinced that "Vorheriger"  is a better wording than "Voriger" in German.
So I changed it in the navigation.

Regards, Frank