### PR TITLE
Misspelled word in translation for German corrected.

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -17,7 +17,7 @@
   translation: "Teilen"
 
 - id: paginatorPrevious
-  translation: "Voherige Seite"
+  translation: "Vorherige Seite"
 
 - id: paginatorNext
   translation: "Nächste Seite"


### PR DESCRIPTION
Unfortunately I misspelled the word that I updated in the last change.