### PR TITLE
Add keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ See [picturingjordan.com](https://picturingjordan.com) for an example of this th
 - Can show a message about cookie usage to the user, see [`exampleSite/config.toml`](https://github.com/alanorth/hugo-theme-bootstrap4-blog/blob/master/exampleSite/config.toml)
 - Allow addition of custom `<head>` code in site's `layouts/partial/head-custom.html` (see [#17](https://github.com/alanorth/hugo-theme-bootstrap4-blog/pull/17))
 - Configurable display of summaries of content in list templates.
+- configurable keywords for every post
 
 ## Usage
 Clone the repository to your site's `themes` directory. Refer to [`exampleSite/config.toml`](https://github.com/alanorth/hugo-theme-bootstrap4-blog/blob/master/exampleSite/config.toml) for recommended configuration values.

--- a/exampleSite/content/post/goisforlovers.md
+++ b/exampleSite/content/post/goisforlovers.md
@@ -13,6 +13,11 @@ categories = [
     "Development",
     "golang",
 ]
+keywords = [
+    "Hugo",
+    "static",
+    "generator",
+]
 menu = "main"
 +++
 

--- a/exampleSite/content/post/hugoisforlovers.md
+++ b/exampleSite/content/post/hugoisforlovers.md
@@ -12,6 +12,11 @@ categories = [
     "Development",
     "golang",
 ]
+keywords = [
+    "Hugo",
+    "static",
+    "generator",
+]
 menu = "main"
 +++
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -39,9 +39,9 @@
     "@type": "Person",
     "name": "{{ .Params.author | default .Site.Params.author }}"
   }
-  {{- if or (.Params.categories) (.Params.tags) -}}
+  {{- if or (.Params.keywords) (or (.Params.categories) (.Params.tags)) -}}
   ,
-  "keywords": "{{ delimit (union .Params.categories .Params.tags) ", " }}"
+  "keywords": "{{ delimit (union .Params.keywords (union .Params.categories .Params.tags)) ", " }}"
   {{- end }}
 
   {{- with .Params.description -}}


### PR DESCRIPTION
Hi Alan,

the keyword generation for blog posts is somewhat limited.
Also the used sources are mainly meant for navigational purposes and don't necessarily match the requirements for keywords.

So I added configurable keywords which can be set on the single post level.

I hope you like the idea.

Regards, Frank