### PR TITLE
layout/_default/baseof.html: Move masthead, header and footer into partial templates

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -32,27 +32,11 @@
   <body>
 
     {{ block "masthead" . }}
-    <div class="blog-masthead">
-      <div class="container">
-        <nav class="nav blog-nav">
-          <a class="nav-link {{ if .IsHome }}active{{ end }}" href="{{ .Site.BaseURL | absLangURL }}">{{ i18n "home" }}</a>
-          {{- $currentPage := . -}}
-          {{ range .Site.Menus.navbar }}
-          {{ $menuURL := .URL | absLangURL }}
-          <a class="nav-link{{ if or ($currentPage.IsMenuCurrent "navbar" .) ($currentPage.HasMenuCurrent "navbar" .) }} active{{end}}" href="{{ .URL }}" title="{{ .Title }}">{{ .Name }}</a>
-          {{ end }}
-        </nav>
-      </div>
-    </div>
+    {{ partial "masthead.html" . }}
     {{ end }}
 
     {{ block "header" . }}
-    <header class="blog-header">
-      <div class="container">
-        <h1 class="blog-title"><a href="{{ .Site.BaseURL }}" rel="home">{{ .Site.Title | safeHTML }}</a></h1>
-        {{ if .Site.Params.description }}<p class="lead blog-description">{{ .Site.Params.description | markdownify }}</p>{{ end }}
-      </div>
-    </header>
+    {{ partial "header.html" . }}
     {{ end }}
 
     {{ block "body" . }}
@@ -73,18 +57,7 @@
     {{ end }}
 
     {{ block "footer" . }}
-    <footer class="blog-footer">
-      <p>
-      {{ if .Site.Copyright }}
-      {{ .Site.Copyright | markdownify }}
-      {{ else }}
-      Blog template created by <a href="https://twitter.com/mdo">@mdo</a>, ported to Hugo by <a href='https://twitter.com/mralanorth'>@mralanorth</a>.
-      {{ end }}
-      </p>
-      <p>
-      <a href="#">{{ i18n "backToTop" }}</a>
-      </p>
-    </footer>
+    {{ partial "footer.html" . }}
     {{ end }}
 
   </body>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,12 @@
+<footer class="blog-footer">
+  <p>
+  {{ if .Site.Copyright }}
+  {{ .Site.Copyright | markdownify }}
+  {{ else }}
+  Blog template created by <a href="https://twitter.com/mdo">@mdo</a>, ported to Hugo by <a href='https://twitter.com/mralanorth'>@mralanorth</a>.
+  {{ end }}
+  </p>
+  <p>
+  <a href="#">{{ i18n "backToTop" }}</a>
+  </p>
+</footer>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,6 @@
+<header class="blog-header">
+  <div class="container">
+    <h1 class="blog-title"><a href="{{ .Site.BaseURL }}" rel="home">{{ .Site.Title | safeHTML }}</a></h1>
+    {{ if .Site.Params.description }}<p class="lead blog-description">{{ .Site.Params.description | markdownify }}</p>{{ end }}
+  </div>
+</header>

--- a/layouts/partials/masthead.html
+++ b/layouts/partials/masthead.html
@@ -1,0 +1,12 @@
+<div class="blog-masthead">
+  <div class="container">
+    <nav class="nav blog-nav">
+      <a class="nav-link {{ if .IsHome }}active{{ end }}" href="{{ .Site.BaseURL | absLangURL }}">{{ i18n "home" }}</a>
+      {{- $currentPage := . -}}
+      {{ range .Site.Menus.navbar }}
+      {{ $menuURL := .URL | absLangURL }}
+      <a class="nav-link{{ if or ($currentPage.IsMenuCurrent "navbar" .) ($currentPage.HasMenuCurrent "navbar" .) }} active{{end}}" href="{{ .URL }}" title="{{ .Title }}">{{ .Name }}</a>
+      {{ end }}
+    </nav>
+  </div>
+</div>


### PR DESCRIPTION
I'd like to override some aspects of how the masthead works
(specifically get rid of the 'Home' menu item and re-implement the rules
for when a navbar item is active). I think the only way to do this
currently is to override the entire baseof.html file.

By moving these three pieces into a partial, it allows more control for
overriding and makes it easier to keep the theme up-to-date.