### PR TITLE
Fix broken navbar

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -39,7 +39,7 @@
           {{- $currentPage := . -}}
           {{ range .Site.Menus.navbar }}
           {{ $menuURL := .URL | absLangURL }}
-          <a class="nav-link{{ if or ($currentPage.IsMenuCurrent "navbar" .) ($currentPage.HasMenuCurrent "navbar" .) }} active{{end}}" href="{{ .URL }}" title="{{ .Title }}">{{ .Name }}</a>
+          <a class="nav-link{{ if or ($currentPage.IsMenuCurrent "navbar" .) ($currentPage.HasMenuCurrent "navbar" .) }} active{{end}}" href="{{ .URL }}" title="{{ .Name }}">{{ .Name }}</a>
           {{ end }}
         </nav>
       </div>


### PR DESCRIPTION
Commit cbd7140 introduced the use of .Title for the navbar generation but menu entries don't have such an attribute.

This fix uses also .Name for the link title.