### PR TITLE
Support baseurl without trailing slash

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -14,10 +14,10 @@
 
     {{ if eq .Lang "ar" }}
     {{ "<!-- ar -->" | safeHTML }}
-    <link href="{{ .Site.BaseURL }}css/style.rtl.css" rel="stylesheet"{{ if not .Site.Params.disable_sri }} integrity="{{ .Site.Data.sri.styleltr}}" crossorigin="anonymous"{{ end }}>
+    <link href="{{ "css/style.rtl.css" | absURL }}" rel="stylesheet"{{ if not .Site.Params.disable_sri }} integrity="{{ .Site.Data.sri.styleltr}}" crossorigin="anonymous"{{ end }}>
     {{ else }}
     {{ "<!-- combined, minified CSS -->" | safeHTML }}
-    <link href="{{ .Site.BaseURL }}css/style.css" rel="stylesheet"{{ if not .Site.Params.disable_sri }} integrity="{{ .Site.Data.sri.style}}" crossorigin="anonymous"{{ end }}>
+    <link href="{{ "css/style.css" | absURL }}" rel="stylesheet"{{ if not .Site.Params.disable_sri }} integrity="{{ .Site.Data.sri.style}}" crossorigin="anonymous"{{ end }}>
     {{ end }}
 
     {{ "<!-- RSS 2.0 feed -->" | safeHTML }}
@@ -55,7 +55,7 @@
     {{ if (ne .Site.Params.header_visible false) }}
     <header class="blog-header">
       <div class="container">
-        <h1 class="blog-title" dir="auto"><a href="{{ .Site.BaseURL }}" rel="home">{{ .Site.Title | safeHTML }}</a></h1>
+        <h1 class="blog-title" dir="auto"><a href="{{ "/" | absURL }}" rel="home">{{ .Site.Title | safeHTML }}</a></h1>
         {{ if .Site.Params.description }}<p class="lead blog-description" dir="auto">{{ .Site.Params.description | markdownify }}</p>{{ end }}
       </div>
     </header>

--- a/layouts/partials/cookie-consent.html
+++ b/layouts/partials/cookie-consent.html
@@ -1,5 +1,5 @@
-<link href="{{ .Site.BaseURL }}css/cookieconsent.min.css" rel="stylesheet" type="text/css"{{ if not .Site.Params.disable_sri }} integrity="{{ .Site.Data.sri.cookieconsentcss }}" crossorigin="anonymous"{{ end }}>
-<script src="{{ .Site.BaseURL }}js/cookieconsent.min.js"{{ if not .Site.Params.disable_sri }} integrity="{{ .Site.Data.sri.cookieconsentjs }}" crossorigin="anonymous"{{ end }} async></script>
+<link href="{{ "css/cookieconsent.min.css" | absURL }}" rel="stylesheet" type="text/css"{{ if not .Site.Params.disable_sri }} integrity="{{ .Site.Data.sri.cookieconsentcss }}" crossorigin="anonymous"{{ end }}>
+<script src="{{ "js/cookieconsent.min.js" |absURL }}"{{ if not .Site.Params.disable_sri }} integrity="{{ .Site.Data.sri.cookieconsentjs }}" crossorigin="anonymous"{{ end }} async></script>
 
 <script>
 window.addEventListener("load", function(){

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,3 +1,3 @@
-Sitemap: {{ .Site.BaseURL }}sitemap.xml
+Sitemap: {{ "sitemap.xml" | absURL }}
 
 User-agent: *


### PR DESCRIPTION
Using a baseurl without a trailing slash such as `baseurl = "https://example.org"` will generate invalid links in the HTML.  
For example this baseurl will generate this incorrect url to the stylesheet `href="https://example.orgcss/style.css"`.

This PR replaces the fragile `.Site.BaseURL` construction with the Hugo [absURL](https://gohugo.io/functions/absurl/) function to generate urls. The documentation mentions trailing slash behaviour:
> absURL and relURL are smart about missing slashes, but they will not add a closing slash to a URL if it is not present.

When you use netlify to host a hugo site netlify can create deploys for feature branches and pull requests. These specific deploys get an automatically generated url which you can access with [environment variables](https://www.netlify.com/docs/continuous-deployment/#environment-variables) such as `DEPLOY_URL` and feed into the hugo invocation. The environment variable values do not include a trailing slash so the site will break when using hugo-theme-bootstrap4-blog.