### PR TITLE
Do not escape characters in formatted date

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -12,7 +12,7 @@
   },
   {{- $ISO8601 := "2006-01-02T15:04:05-07:00" }}
   {{- if not .Date.IsZero }}
-  "dateModified": "{{ .Date.Format $ISO8601 }}",
+  "dateModified": {{ .Date.Format $ISO8601 }},
   {{- end }}
   {{- with .Site.Social.GooglePlus }}
   "publisher": "{{ printf "%s" . }}",

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -25,12 +25,12 @@
   "wordCount": "{{ .WordCount }}",
   {{- $ISO8601 := "2006-01-02T15:04:05-07:00" }}
   {{- if not .PublishDate.IsZero }}
-  "datePublished": "{{ .PublishDate.Format $ISO8601 }}",
+  "datePublished": {{ .PublishDate.Format $ISO8601 }},
   {{- else }}
-  "datePublished": "{{ .Date.Format $ISO8601 }}",
+  "datePublished": {{ .Date.Format $ISO8601 }},
   {{- end }}
   {{- if not .Lastmod.IsZero }}
-  "dateModified": "{{ .Lastmod.Format $ISO8601 }}",
+  "dateModified": {{ .Lastmod.Format $ISO8601 }},
   {{- end }}
   {{- with .Site.Social.GooglePlus }}
   "publisher": "{{ printf "%s" . }}",


### PR DESCRIPTION
Remove quotes in the template so that the '+' character will no longer needlessly be escaped as '\x2b'.  
Because the + character is part of the datetime it will render an invalid date in the JSON Linked Data, which may hurt SEO.

Without this fix:
```html
<script type="application/ld+json">
...
"dateModified": "2014-09-28T00:00:00\x2b00:00",
...
</script>
```

With this fix:
```html
<script type="application/ld+json">
...
"dateModified": "2014-09-28T00:00:00+00:00",
...
</script>
```