### PR TITLE
Fixed invalid URL if blog is not in domain root

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -45,3 +45,7 @@
 
 - id: comma
   translation: ","
+
+- id: tags
+  translation: "Tags"
+

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -46,6 +46,9 @@
 - id: comma
   translation: ","
 
+- id: projects
+  translation: "Projects"
+
 - id: tags
   translation: "Tags"
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -40,11 +40,14 @@
     <div class="blog-masthead">
       <div class="container">
         <nav class="nav blog-nav">
-          <a class="nav-link {{ if .IsHome }}active{{ end }}" href="{{ .Site.BaseURL | absLangURL }}">{{ i18n "home" }}</a>
           {{- $currentPage := . -}}
           {{ range .Site.Menus.navbar }}
-          {{ $menuURL := .URL | absLangURL }}
-          <a class="nav-link{{ if or ($currentPage.IsMenuCurrent "navbar" .) ($currentPage.HasMenuCurrent "navbar" .) }} active{{end}}" href="{{ .URL }}" title="{{ .Title }}">{{ .Name }}</a>
+            {{ if eq .URL "/" }}
+              <a class="nav-link {{ if .IsHome }}active{{ end }}" href="{{ .Site.BaseURL | absLangURL }}">{{ i18n "home" }}</a>
+            {{ else }}
+              {{ $menuURL := .URL | absLangURL }}
+              <a class="nav-link{{ if or ($currentPage.IsMenuCurrent "navbar" .) ($currentPage.HasMenuCurrent "navbar" .) }} active{{end}}" href="{{ .URL }}" title="{{ .Title }}">{{ .Name }}</a>
+            {{ end }}
           {{ end }}
         </nav>
       </div>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -55,7 +55,7 @@
     {{ if (ne .Site.Params.header_visible false) }}
     <header class="blog-header">
       <div class="container">
-        <h1 class="blog-title" dir="auto"><a href="{{ "/" | absURL }}" rel="home">{{ .Site.Title | safeHTML }}</a></h1>
+        <h1 class="blog-title" dir="auto"><a href="{{ .Site.BaseURL | absURL }}" rel="home">{{ .Site.Title | safeHTML }}</a></h1>
         {{ if .Site.Params.description }}<p class="lead blog-description" dir="auto">{{ .Site.Params.description | markdownify }}</p>{{ end }}
       </div>
     </header>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -42,12 +42,8 @@
         <nav class="nav blog-nav">
           {{- $currentPage := . -}}
           {{ range .Site.Menus.navbar }}
-            {{ if eq .URL "/" }}
-              <a class="nav-link {{ if .IsHome }}active{{ end }}" href="{{ .Site.BaseURL | absLangURL }}">{{ i18n "home" }}</a>
-            {{ else }}
-              {{ $menuURL := .URL | absLangURL }}
-              <a class="nav-link{{ if or ($currentPage.IsMenuCurrent "navbar" .) ($currentPage.HasMenuCurrent "navbar" .) }} active{{end}}" href="{{ .URL }}" title="{{ .Title }}">{{ .Name }}</a>
-            {{ end }}
+            {{ $menuURL := .URL | absLangURL }}
+            <a class="nav-link{{ if or ($currentPage.IsMenuCurrent "navbar" .) ($currentPage.HasMenuCurrent "navbar" .) }} active{{end}}" href="{{ .URL }}" title="{{ .Title }}">{{ .Name }}</a>
           {{ end }}
         </nav>
       </div>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -12,10 +12,10 @@
 
   {{ with .Site.Menus.sidebar }}
   <section class="sidebar-module">
-    <h4>{{ i18n "links" }}</h4>
+    <h4>{{ i18n "projects" }}</h4>
     <ol class="list-unstyled">
       {{ range . }}
-      <li><a href="{{ .URL | absURL }}">{{ .Name }}</a></li>
+      <li>&gt; <a href="{{ .URL | absURL }}">{{ .Name }}</a> &lt;</li>
       {{ end }}
     </ol>
   </section>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -20,6 +20,18 @@
     </ol>
   </section>
   {{ end }}
+
+  {{ if .Site.Params.sidebar }}
+  <section class="sidebar-module">
+    <h4>{{ i18n "tags" }}</h4>
+    <ul>
+      {{ range $name, $items := .Site.Taxonomies.tags }}
+      <li><a href="{{ "tags/" | relLangURL }}{{ $name | urlize | lower }}" title="{{ $name }}">{{ .Page.Title }} ({{ .Count }})</a>&emsp;</li>
+      {{ end }}
+    </ul>
+  </section>
+  {{ end }}
+
 </aside><!-- /.blog-sidebar -->
 
 {{- /* vim: set ts=2 sw=2 et: */}}


### PR DESCRIPTION
It fixes a problem with a site, that resides not on domain root, i.e. `https://domain.com/blog`
'Title' of each page should lead then to `/blog` URL instead it navigates directly to the root.