### PR TITLE
uses html-minifier, by default --preserve-line-breaks to keep code re…

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "build:rtlcss": "rtlcss -s assets/css/style.css.tmp assets/css/style.rtl.css.tmp && cleancss --level 1 assets/css/style.rtl.css.tmp -o assets/css/style.rtl.css",
     "build:fonts": "cp node_modules/@fortawesome/fontawesome-free/webfonts/* static/webfonts",
     "build:cookieconsent": "cp node_modules/cookieconsent/build/cookieconsent.min.css assets/css && cp node_modules/cookieconsent/build/cookieconsent.min.js assets/js",
+    "minify:html": "html-minifier --input-dir ../../public --output-dir ../../public-out --collapse-whitespace --preserve-line-breaks --file-ext html",
+    "build:html": "npm run minify:html",
+    "watch:html": "onchange 'src/**/*.html -- npm run build:html",
     "build": "npm run build:css && npm run build:rtlcss && npm run build:fonts && npm run build:cookieconsent && npm run clean",
     "clean": "rm assets/css/style.css.tmp assets/css/style.rtl.css.tmp"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "minify:html": "html-minifier --input-dir ../../public --output-dir ../../public-out --collapse-whitespace --preserve-line-breaks --file-ext html",
     "build:html": "npm run minify:html",
     "watch:html": "onchange 'src/**/*.html -- npm run build:html",
-    "build": "npm run build:css && npm run build:rtlcss && npm run build:fonts && npm run build:cookieconsent && npm run clean",
+    "build": "npm run build:css && npm run build:rtlcss && npm run build:fonts && npm run build:cookieconsent && npm run build:html && npm run clean",
     "clean": "rm assets/css/style.css.tmp assets/css/style.rtl.css.tmp"
   },
   "keywords": "hugo",


### PR DESCRIPTION
cd ~/hugo/mysite/themes/hugo-theme-bootstrap4-blog
npm install html-minifier

html-minifier, by default --preserve-line-breaks to keep code readable, can be further minified if that parameter is removed.

Please look it over to make sure its ready for the masses. This is working great on my site for cleaning up the html source code.

OH! Also after running **npm run build** and **hugo -D**
next I overwrite the contents of **/public** with **/public-out** overwriting the original files with minified files.