### PR TITLE
Allow content without PublishDate, eliminates extraneous date output.

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -56,7 +56,9 @@
 <article class="blog-post">
   <header>
     <h2 class="blog-post-title" dir="auto"><a href="{{ .Permalink }}">{{ .Title | markdownify }}</a></h2>
-    <p class="blog-post-meta"><time {{ .Date.Format "2006-01-02T15:04:05Z07:00" | printf "datetime=%q" | safeHTMLAttr }}>{{ .Date.Format $dateFormat }}</time> {{ i18n "authoredBy" }} {{ .Params.author | default .Site.Params.author }}{{ if or (.Params.categories) (.Params.tags) }} {{ i18n "postedIn" }} {{ partial "meta-terms.html" . }}{{ end }}</p>
+    <p class="blog-post-meta">
+{{ if not .PublishDate.IsZero }}<time {{ .Date.Format "2006-01-02T15:04:05Z07:00" | printf "datetime=%q" | safeHTMLAttr }}>{{ .Date.Format $dateFormat }}</time>{{ end }}
+{{ if or (.Params.categories) (.Params.tags) }} {{ i18n "postedIn" }} {{ partial "meta-terms.html" . }}{{ end }}</p>
   </header>
   {{ .Content }}
 


### PR DESCRIPTION
Some pages (e.g. an About Us page) I don't want to display a PublishedDate.  I can simply omit the date front-matter, but then the page displays an extraneous date:

```
<p class="blog-post-meta">
<time datetime="0001-01-01T00:00:00Z">
</p>
```

The proposed change will omit timestamp when date is not set.
